### PR TITLE
fix height size keeping aspect ratio

### DIFF
--- a/src/gifa11y.js
+++ b/src/gifa11y.js
@@ -142,12 +142,9 @@ class Gifa11y {
 						}
 					}
 
-					//If rendered or clientHeight of image is 0, use naturalHeight as fallback.
-					if ($el.clientHeight == 0) {
-						canvas.height = $el.naturalHeight + 0.5;
-					} else {
-						canvas.height = $el.clientHeight + 0.5;
-					}
+					// Calculate gif height keeping aspect ratio.
+					const newHeight = ( $el.naturalHeight / $el.naturalWidth ) * canvas.width;
+					canvas.height = newHeight;
 
 					canvas.setAttribute('role', 'img');
 

--- a/src/gifa11y.js
+++ b/src/gifa11y.js
@@ -144,7 +144,7 @@ class Gifa11y {
 
 					// Calculate gif height keeping aspect ratio.
 					const newHeight = ( $el.naturalHeight / $el.naturalWidth ) * canvas.width;
-					canvas.height = newHeight;
+					canvas.height = newHeight + 0.5;
 
 					canvas.setAttribute('role', 'img');
 


### PR DESCRIPTION
## The problem
I found some instances where the height of the GIF was miscalculated shrinking the GIF so I found that using clientHeight as the canvas height leads (in some cases) to this error

## The fix  
 I replaced the `canvas.height` assignment part using an aspect ratio calculation which seems to work just fine with different sizes (vertical and landscape)